### PR TITLE
Minor optimizations

### DIFF
--- a/CSharpWars/CSharpWars.Common/Extensions/LoggerExtensions.cs
+++ b/CSharpWars/CSharpWars.Common/Extensions/LoggerExtensions.cs
@@ -7,6 +7,11 @@ public static class LoggerExtensions
 {
     public static void AutoLogInformation<TCategoryName>(this ILogger<TCategoryName> logger, string message, [CallerMemberName] string caller = "<unknown caller>")
     {
-        logger.LogInformation($"{DateTime.UtcNow:dd-MM-yyyy HH:mm:ss} | {typeof(TCategoryName).Name}.{caller} | {message}");
+        logger.LogInformation(
+            "{UtcNow:dd-MM-yyyy HH:mm:ss} | {CategoryTypeName}.{Caller} | {Message}",
+            DateTime.UtcNow,
+            typeof(TCategoryName).Name,
+            caller,
+            message);
     }
 }

--- a/CSharpWars/CSharpWars.Common/Helpers/RandomHelper.cs
+++ b/CSharpWars/CSharpWars.Common/Helpers/RandomHelper.cs
@@ -4,14 +4,14 @@ public interface IRandomHelper
 {
     int Get(int max);
     int Get(int min, int max);
-    TEnum Get<TEnum>() where TEnum : Enum;
+    TEnum Get<TEnum>() where TEnum : struct, Enum;
     TItem GetItem<TItem>(List<TItem> items);
     TItem GetItem<TItem>(TItem[] items);
 }
 
 public class RandomHelper : IRandomHelper
 {
-    private readonly Random _random = new();
+    private readonly Random _random = Random.Shared;
 
     public int Get(int max)
     {
@@ -23,12 +23,12 @@ public class RandomHelper : IRandomHelper
         return _random.Next(min, max);
     }
 
-    public TEnum Get<TEnum>() where TEnum : Enum
+    public TEnum Get<TEnum>() where TEnum : struct, Enum
     {
-        var values = Enum.GetValues(typeof(TEnum));
+        var values = Enum.GetValues<TEnum>();
         var indexOfValue = _random.Next(values.Length);
 
-        return (TEnum)values.GetValue(indexOfValue) ?? default;
+        return values[indexOfValue];
     }
 
     public TItem GetItem<TItem>(List<TItem> items)

--- a/CSharpWars/CSharpWars.Orleans.Common/GrainBase.cs
+++ b/CSharpWars/CSharpWars.Orleans.Common/GrainBase.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpWars.Common.Extensions;
 using Microsoft.Extensions.Logging;
-using Orleans;
 
 namespace CSharpWars.Orleans.Common;
 

--- a/CSharpWars/CSharpWars.Orleans.Common/GrainFactoryExtensions.cs
+++ b/CSharpWars/CSharpWars.Orleans.Common/GrainFactoryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Common;
+﻿namespace CSharpWars.Orleans.Common;
 
 public static class GrainFactoryExtensions
 {

--- a/CSharpWars/CSharpWars.Orleans.Common/GrainFactoryHelper.cs
+++ b/CSharpWars/CSharpWars.Orleans.Common/GrainFactoryHelper.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Common;
+﻿namespace CSharpWars.Orleans.Common;
 
 public interface IGrainFactoryHelper<TGrainInterface> where TGrainInterface : IGrainWithGuidKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/ArenaDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/ArenaDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class ArenaDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/BotDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/BotDto.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Enums;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/BotToCreateDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/BotToCreateDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class BotToCreateDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ArenaGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ArenaGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IArenaGrain : IGrainWithStringKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/BotGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/BotGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IBotGrain : IGrainWithGuidKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/MessagesGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/MessagesGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IMessagesGrain : IGrainWithStringKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/MovesGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/MovesGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IMovesGrain : IGrainWithStringKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/PlayerGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/PlayerGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IPlayerGrain : IGrainWithStringKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/PlayersGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/PlayersGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IPlayersGrain : IGrainWithGuidKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ProcessingGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ProcessingGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IProcessingGrain : IGrainWithStringKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ScriptGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ScriptGrain.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Orleans.Contracts.Model;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts.Grains;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/StatusGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/StatusGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IStatusGrain : IGrainWithGuidKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ValidationGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Grains/ValidationGrain.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts.Grains;
+﻿namespace CSharpWars.Orleans.Contracts.Grains;
 
 public interface IValidationGrain : IGrainWithGuidKey
 {

--- a/CSharpWars/CSharpWars.Orleans.Contracts/MessageDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/MessageDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class MessageDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Model/Bot.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Model/Bot.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Enums;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts.Model;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Model/BotProperties.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Model/BotProperties.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpWars.Common.Extensions;
 using CSharpWars.Enums;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts.Model;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/Model/Vision.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/Model/Vision.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Enums;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts.Model;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/MoveDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/MoveDto.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Enums;
-using Orleans;
 
 namespace CSharpWars.Orleans.Contracts;
 

--- a/CSharpWars/CSharpWars.Orleans.Contracts/PlayerDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/PlayerDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class PlayerDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/ScriptToValidateDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/ScriptToValidateDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class ScriptToValidateDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/StatusDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/StatusDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class StatusDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/ValidatedScriptDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/ValidatedScriptDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class ValidatedScriptDto

--- a/CSharpWars/CSharpWars.Orleans.Contracts/ValidatedScriptMessageDto.cs
+++ b/CSharpWars/CSharpWars.Orleans.Contracts/ValidatedScriptMessageDto.cs
@@ -1,6 +1,4 @@
-﻿using Orleans;
-
-namespace CSharpWars.Orleans.Contracts;
+﻿namespace CSharpWars.Orleans.Contracts;
 
 [GenerateSerializer]
 public class ValidatedScriptMessageDto

--- a/CSharpWars/CSharpWars.Orleans.Grains/ArenaGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/ArenaGrain.cs
@@ -66,8 +66,9 @@ public class ArenaGrain : GrainBase<IArenaGrain>, IArenaGrain
 
         if (_state.State.BotIds != null)
         {
-            foreach (var botId in _state.State.BotIds)
+            for (int i = 0; i < _state.State.BotIds.Count; i++)
             {
+                Guid botId = _state.State.BotIds[i];
                 var botState = await _botGrainFactory.FromGrain(botId, g => g.GetState());
 
                 if (!onlyLive || botState.Move != Move.Died)
@@ -134,8 +135,9 @@ public class ArenaGrain : GrainBase<IArenaGrain>, IArenaGrain
 
             await Task.Delay(2000);
 
-            foreach (var botId in _state.State.BotIds)
+            for (int i = 0; i < _state.State.BotIds.Count; i++)
             {
+                Guid botId = _state.State.BotIds[i];
                 await _botGrainFactory.FromGrain(botId, g => g.DeleteBot(true));
             }
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/BotGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/BotGrain.cs
@@ -6,7 +6,6 @@ using CSharpWars.Orleans.Contracts;
 using CSharpWars.Orleans.Contracts.Exceptions;
 using CSharpWars.Orleans.Contracts.Grains;
 using Microsoft.Extensions.Logging;
-using Orleans;
 using Orleans.Runtime;
 
 namespace CSharpWars.Orleans.Grains;

--- a/CSharpWars/CSharpWars.Orleans.Grains/BotGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/BotGrain.cs
@@ -98,7 +98,7 @@ public class BotGrain : GrainBase<IBotGrain>, IBotGrain
         _state.State.CurrentStamina = bot.MaximumStamina;
         _state.State.MaximumStamina = bot.MaximumStamina;
         _state.State.Orientation = _randomHelper.Get<Orientation>();
-        (_state.State.X, _state.State.Y) = await FindFreeLocation(arena, activeBots);
+        (_state.State.X, _state.State.Y) = FindFreeLocation(arena, activeBots);
         (_state.State.FromX, _state.State.FromY) = (_state.State.X, _state.State.Y);
         _state.State.Memory = new Dictionary<string, string>().Serialize();
         _state.State.TimeOfDeath = DateTime.MaxValue;
@@ -113,7 +113,7 @@ public class BotGrain : GrainBase<IBotGrain>, IBotGrain
         return await GetState();
     }
 
-    private async Task<(int X, int Y)> FindFreeLocation(ArenaDto arena, List<BotDto> activeBots)
+    private (int X, int Y) FindFreeLocation(ArenaDto arena, List<BotDto> activeBots)
     {
         var freeLocations = new List<(int X, int Y)>();
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/PostprocessingLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/PostprocessingLogic.cs
@@ -44,8 +44,9 @@ public class PostprocessingLogic : IPostprocessingLogic
         var botProperties = context.GetOrderedBotProperties();
         var botLog = new List<BotLog>();
 
-        foreach (var botProperty in botProperties)
+        for (int i = 0; i < botProperties.Count; i++)
         {
+            Contracts.Model.BotProperties? botProperty = botProperties[i];
             var bot = context.Bots.Single(x => x.BotId == botProperty.BotId);
             var botResult = BaseMove.Build(botProperty, _randomHelper).Go();
             bot.Orientation = botResult.Orientation;
@@ -80,8 +81,9 @@ public class PostprocessingLogic : IPostprocessingLogic
             await LogMove(context.Arena.Name, bot.BotName, bot.PlayerName, botResult.Move);
         }
 
-        foreach (var bot in context.Bots)
+        for (int i = 0; i < context.Bots.Count; i++)
         {
+            BotDto bot = context.Bots[i];
             if (bot.CurrentHealth <= 0)
             {
                 bot.CurrentHealth = 0;

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/PreprocessingLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/PreprocessingLogic.cs
@@ -12,8 +12,9 @@ public class PreprocessingLogic : IPreprocessingLogic
 {
     public Task Go(ProcessingContext context)
     {
-        foreach (var bot in context.Bots)
+        for (int i = 0; i < context.Bots.Count; i++)
         {
+            Contracts.BotDto bot = context.Bots[i];
             var botProperties = BotProperties.Build(bot, context.Arena, context.Bots);
             context.AddBotProperties(bot.BotId, botProperties);
         }

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessingLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessingLogic.cs
@@ -24,8 +24,9 @@ public class ProcessingLogic : IProcessingLogic
     {
         var tasks = new Dictionary<Guid, Task<BotProperties>>();
 
-        foreach (var bot in context.Bots)
+        for (int i = 0; i < context.Bots.Count; i++)
         {
+            Contracts.BotDto? bot = context.Bots[i];
             var botProperties = context.GetBotProperties(bot.BotId);
             var task = _scriptGrainFactory.FromGrain(bot.BotId, g => g.Process(botProperties));
             tasks.Add(bot.BotId, task);

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessingLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessingLogic.cs
@@ -1,5 +1,4 @@
 ﻿using CSharpWars.Scripting;
-using System.ComponentModel.Design.Serialization;
 using CSharpWars.Orleans.Common;
 using CSharpWars.Orleans.Contracts.Grains;
 using CSharpWars.Orleans.Contracts.Model;

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessorLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessorLogic.cs
@@ -50,16 +50,18 @@ public class ProcessorLogic : IProcessorLogic
 
         await _postprocessingLogic.Go(context);
 
-        foreach (var bot in allBots)
+        for (int i = 0; i < allBots.Count; i++)
         {
+            Contracts.BotDto? bot = allBots[i];
             if (bot.TimeOfDeath < DateTime.UtcNow.AddSeconds(-10))
             {
                 await _botGrainFactory.FromGrain(bot.BotId, g => g.DeleteBot(false));
             }
         }
 
-        foreach (var bot in context.Bots)
+        for (int i = 0; i < context.Bots.Count; i++)
         {
+            Contracts.BotDto? bot = context.Bots[i];
             await _botGrainFactory.FromGrain(bot.BotId, g => g.UpdateState(bot));
         }
     }

--- a/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessorLogic.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/Logic/ProcessorLogic.cs
@@ -1,5 +1,4 @@
-﻿using CSharpWars.Enums;
-using CSharpWars.Orleans.Common;
+﻿using CSharpWars.Orleans.Common;
 using CSharpWars.Orleans.Contracts.Grains;
 using CSharpWars.Scripting;
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/PlayerGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/PlayerGrain.cs
@@ -124,8 +124,9 @@ public class PlayerGrain : GrainBase<IPlayerGrain>, IPlayerGrain
         {
             _logger.AutoLogInformation($"Deleting player '{_state.State.Username}' and all of its bots");
 
-            foreach (var botId in _state.State.BotIds)
+            for (int i = 0; i < _state.State.BotIds.Count; i++)
             {
+                Guid botId = _state.State.BotIds[i];
                 await _botGrainHelper.FromGrain(botId, g => g.DeleteBot(false));
             }
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/PlayersGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/PlayersGrain.cs
@@ -61,8 +61,9 @@ public class PlayersGrain : GrainBase<IPlayersGrain>, IPlayersGrain
         {
             _logger.AutoLogInformation("All players will be deleted");
 
-            foreach (var playerName in _state.State.PlayerNames)
+            for (int i = 0; i < _state.State.PlayerNames.Count; i++)
             {
+                string? playerName = _state.State.PlayerNames[i];
                 await _playerGrainFactoryHelper.FromGrain(playerName, g => g.DeletePlayer());
             }
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/ProcessingGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/ProcessingGrain.cs
@@ -3,7 +3,6 @@ using CSharpWars.Orleans.Common;
 using CSharpWars.Orleans.Contracts.Grains;
 using CSharpWars.Orleans.Grains.Logic;
 using Microsoft.Extensions.Logging;
-using Orleans;
 
 namespace CSharpWars.Orleans.Grains;
 

--- a/CSharpWars/CSharpWars.Orleans.Grains/ScriptGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/ScriptGrain.cs
@@ -64,7 +64,7 @@ public class ScriptGrain : GrainBase<IScriptGrain>, IScriptGrain
 
                 _ = await _compiledScript.Invoke(scriptGlobals);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 botProperties.CurrentMove = Move.ScriptError;
                 botProperties.Message = ex.Message;

--- a/CSharpWars/CSharpWars.Orleans.Grains/StatusGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Grains/StatusGrain.cs
@@ -15,14 +15,14 @@ public class StatusGrain : GrainBase<IStatusGrain>, IStatusGrain
         _logger = logger;
     }
 
-    public async Task<StatusDto> GetStatus()
+    public Task<StatusDto> GetStatus()
     {
         var message = "Hi from the <StatusGrain>";
         _logger.AutoLogInformation(message);
 
-        return new StatusDto
+        return Task.FromResult(new StatusDto
         {
             Message = message
-        };
+        });
     }
 }

--- a/CSharpWars/CSharpWars.Orleans.Host/Program.cs
+++ b/CSharpWars/CSharpWars.Orleans.Host/Program.cs
@@ -5,7 +5,7 @@ using CSharpWars.Scripting;
 using Orleans.Configuration;
 using System.Net;
 
-IHost host = Host.CreateDefaultBuilder(args)
+using IHost host = Host.CreateDefaultBuilder(args)
 
     .ConfigureAppConfiguration(config =>
     {
@@ -29,7 +29,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 #if DEBUG
         siloBuilder.UseLocalhostClustering(siloPort: 11112, gatewayPort: 30001, primarySiloEndpoint: new IPEndPoint(IPAddress.Loopback, 11112), serviceId: "csharpwars-orleans-host", clusterId: "csharpwars-orleans-host");
 #else
-        if( shouldUseKubernetes)
+        if (shouldUseKubernetes)
         {
             siloBuilder.UseKubernetesHosting();
         }

--- a/CSharpWars/CSharpWars.Orleans.Validation.Grains/ValidationGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Validation.Grains/ValidationGrain.cs
@@ -6,7 +6,6 @@ using CSharpWars.Orleans.Contracts.Grains;
 using CSharpWars.Orleans.Contracts.Model;
 using CSharpWars.Scripting;
 using Microsoft.CodeAnalysis;
-using Orleans;
 
 namespace CSharpWars.Orleans.Validation.Grains;
 

--- a/CSharpWars/CSharpWars.Orleans.Validation.Grains/ValidationGrain.cs
+++ b/CSharpWars/CSharpWars.Orleans.Validation.Grains/ValidationGrain.cs
@@ -22,9 +22,9 @@ public class ValidationGrain : Grain, IValidationGrain
 
     public async Task<ValidatedScriptDto> Validate(ScriptToValidateDto scriptToValidate)
     {
-        var compilationStopwatch = Stopwatch.StartNew();
+        var compilationStartingTime = Stopwatch.GetTimestamp();
         var diagnostics = await _scriptCompiler.CompileForDiagnostics(scriptToValidate.Script);
-        compilationStopwatch.Stop();
+        var compilationElapsedTime = Stopwatch.GetElapsedTime(compilationStartingTime);
 
         var botScript = await _scriptCompiler.CompileForExecution(scriptToValidate.Script);
 
@@ -85,7 +85,7 @@ public class ValidationGrain : Grain, IValidationGrain
                 var botProperties = BotProperties.Build(bot, arena, new[] { bot, friendBot, enemyBot }.ToList());
                 var scriptGlobals = ScriptGlobals.Build(botProperties);
 
-                var runtimeStopwatch = Stopwatch.StartNew();
+                var runtimeStartingTime = Stopwatch.GetTimestamp();
 
                 try
                 {
@@ -99,8 +99,8 @@ public class ValidationGrain : Grain, IValidationGrain
                     });
                 }
 
-                runtimeStopwatch.Stop();
-                runtimeInMilliseconds = runtimeStopwatch.ElapsedMilliseconds;
+                var runtimeElapsedTime = Stopwatch.GetElapsedTime(runtimeStartingTime);
+                runtimeInMilliseconds = runtimeElapsedTime.Milliseconds;
             });
 
             if (!task.Wait(TimeSpan.FromSeconds(1)))
@@ -129,7 +129,7 @@ public class ValidationGrain : Grain, IValidationGrain
 
         return new ValidatedScriptDto
         {
-            CompilationTimeInMilliseconds = compilationStopwatch.ElapsedMilliseconds,
+            CompilationTimeInMilliseconds = compilationElapsedTime.Milliseconds,
             RunTimeInMilliseconds = runtimeInMilliseconds,
             ValidationMessages = validationMessages
         };

--- a/CSharpWars/CSharpWars.Orleans.Validation.Host/Program.cs
+++ b/CSharpWars/CSharpWars.Orleans.Validation.Host/Program.cs
@@ -3,7 +3,7 @@ using CSharpWars.Scripting;
 using Orleans.Configuration;
 using System.Net;
 
-IHost host = Host.CreateDefaultBuilder(args)
+using IHost host = Host.CreateDefaultBuilder(args)
 
     .ConfigureAppConfiguration(config =>
     {
@@ -25,7 +25,7 @@ IHost host = Host.CreateDefaultBuilder(args)
 #if DEBUG
         siloBuilder.UseLocalhostClustering(siloPort: 11111, gatewayPort: 30000, primarySiloEndpoint: new IPEndPoint(IPAddress.Loopback, 11112), serviceId: "csharpwars-orleans-host", clusterId: "csharpwars-orleans-host");
 #else
-        if(shouldUseKubernetes)
+        if (shouldUseKubernetes)
         {
             siloBuilder.UseKubernetesHosting();
         }

--- a/CSharpWars/CSharpWars.Scripting/BotResult.cs
+++ b/CSharpWars/CSharpWars.Scripting/BotResult.cs
@@ -50,7 +50,7 @@ public class BotResult
 
     public int GetInflictedDamage(Guid botId)
     {
-        return _damageInflicted.ContainsKey(botId) ? _damageInflicted[botId] : 0;
+        return _damageInflicted.TryGetValue(botId, out int value) ? value : 0;
     }
 
     public void Teleport(Guid botId, int destinationX, int destinationY)
@@ -65,6 +65,6 @@ public class BotResult
 
     public (int X, int Y) GetTeleportation(Guid botId)
     {
-        return _teleportations.ContainsKey(botId) ? _teleportations[botId] : (-1, -1);
+        return _teleportations.TryGetValue(botId, out (int X, int Y) value) ? value : (-1, -1);
     }
 }

--- a/CSharpWars/CSharpWars.Scripting/MoveComparer.cs
+++ b/CSharpWars/CSharpWars.Scripting/MoveComparer.cs
@@ -6,25 +6,29 @@ public class MoveComparer : IComparer<Move>
 {
     public static MoveComparer Default => new();
 
-    private readonly Dictionary<Move, int> _weights = new()
-    {
-        { Move.Idling, 0 },
-        { Move.Died, 0 },
-        { Move.ScriptError, 0 },
-        { Move.RangedAttack, 1 },
-        { Move.MeleeAttack, 2 },
-        { Move.SelfDestruct, 3 },
-        { Move.Teleport, 4 },
-        { Move.WalkForward, 5 },
-        { Move.TurningLeft, 6 },
-        { Move.TurningRight, 6 },
-        { Move.TurningAround, 6 }
-    };
-
     private MoveComparer() { }
 
     public int Compare(Move x, Move y)
     {
-        return _weights[x].CompareTo(_weights[y]);
+        return MoveWeight(x).CompareTo(MoveWeight(y));
+
+        static int MoveWeight(Move move)
+        {
+            return move switch
+            {
+                Move.Idling => 0,
+                Move.Died => 0,
+                Move.ScriptError => 0,
+                Move.RangedAttack => 1,
+                Move.MeleeAttack => 2,
+                Move.SelfDestruct => 3,
+                Move.Teleport => 4,
+                Move.WalkForward => 5,
+                Move.TurningLeft => 6,
+                Move.TurningRight => 6,
+                Move.TurningAround => 6,
+                _ => 0
+            };
+        }
     }
 }

--- a/CSharpWars/CSharpWars.Scripting/ScriptGlobals.cs
+++ b/CSharpWars/CSharpWars.Scripting/ScriptGlobals.cs
@@ -169,9 +169,10 @@ public class ScriptGlobals
     /// <returns></returns>
     public T? LoadFromMemory<T>(string key)
     {
-        if (_50437079C366407D978Fe4Afd60C535F.Memory.ContainsKey(key))
+        if (_50437079C366407D978Fe4Afd60C535F.Memory.TryGetValue(key, out string? value) 
+            && value is not null)
         {
-            return _50437079C366407D978Fe4Afd60C535F.Memory[key].Deserialize<T>();
+            return value.Deserialize<T>();
         }
 
         return default;
@@ -183,10 +184,7 @@ public class ScriptGlobals
     /// <param name="key"></param>
     public void RemoveFromMemory(string key)
     {
-        if (_50437079C366407D978Fe4Afd60C535F.Memory.ContainsKey(key))
-        {
-            _50437079C366407D978Fe4Afd60C535F.Memory.Remove(key);
-        }
+        _50437079C366407D978Fe4Afd60C535F.Memory.Remove(key);
     }
 
     /// <summary>

--- a/CSharpWars/CSharpWars.Web/Controllers/HomeController.cs
+++ b/CSharpWars/CSharpWars.Web/Controllers/HomeController.cs
@@ -2,7 +2,6 @@
 using CSharpWars.Web.Client;
 using CSharpWars.Web.Extensions;
 using CSharpWars.Web.Models;
-using CSharpWars.WebApi.Contracts;
 using Microsoft.AspNetCore.Mvc;
 
 namespace CSharpWars.Web.Controllers;

--- a/CSharpWars/CSharpWars.Web/Controllers/PlayController.cs
+++ b/CSharpWars/CSharpWars.Web/Controllers/PlayController.cs
@@ -22,7 +22,7 @@ public class PlayController : Controller
         _orleansClient = orleansClient;
     }
 
-    public async Task<IActionResult> Template()
+    public IActionResult Template()
     {
         if (HttpContext.Session.Keys.Contains("PLAYER"))
         {

--- a/CSharpWars/CSharpWars.WebApi/Helpers/ApiHelper.cs
+++ b/CSharpWars/CSharpWars.WebApi/Helpers/ApiHelper.cs
@@ -55,11 +55,12 @@ public class ApiHelper<TManager> : IApiHelper<TManager>
     {
         try
         {
-            var stopwatch = Stopwatch.StartNew();
+            var startingTimestamp = Stopwatch.GetTimestamp();
 
             var result = await action();
 
-            _logger.LogTrace($"REQUEST: {stopwatch.ElapsedMilliseconds}ms");
+            var elapsedTime = Stopwatch.GetElapsedTime(startingTimestamp);
+            _logger.LogTrace("REQUEST: {Milliseconds}ms", elapsedTime.Milliseconds);
 
             return result;
         }

--- a/CSharpWars/CSharpWars.WebApi/Program.cs
+++ b/CSharpWars/CSharpWars.WebApi/Program.cs
@@ -32,7 +32,7 @@ builder.Host.UseOrleans((hostBuilder, siloBuilder) =>
 #if DEBUG
     siloBuilder.UseLocalhostClustering(siloPort: 11113, gatewayPort: 30002, primarySiloEndpoint: new IPEndPoint(IPAddress.Loopback, 11112), serviceId: "csharpwars-orleans-host", clusterId: "csharpwars-orleans-host");
 #else
-    if( shouldUseKubernetes)
+    if (shouldUseKubernetes)
     {
         siloBuilder.UseKubernetesHosting();
     }


### PR DESCRIPTION
In this PR:

- Remove and sort all usings, `Orleans` for example isn't required as it's implicitly available.
- Prefer `for` loops instead of `foreach` when the collection type isn't `IEnumerable<T>`.
- Correct logging method calls, should use message templates, not interpolated strings.
- Use `Enum.GetValues<TEnum>()` instead of `Enum.GetValues(typeof(TEnum))`.
- Use `Random.Shared` instead of `new()`.
- Cache `Assembly` references rather than perform reflection n-number of times.
- A few places, I observed `async` methods without `await` expressions:
  - Some cases simply removed `async Task<T>`, and return `T`.
  - Other cases, removed `async` and returned `Task.FromResult`.
- Use `TryGet*` APIs to avoid double lookups where possible.
- Use `Stopwatch.GetTimestamp` and `Stopwatch.GetElapsedTime` APIs instead of `Stopwatch.StartNew`.